### PR TITLE
ci: use repository owner as "Update userscripts" PR reviewer

### DIFF
--- a/.github/workflows/update-userscripts.yml
+++ b/.github/workflows/update-userscripts.yml
@@ -37,4 +37,4 @@ jobs:
                   body: |
                       This PR was automatically generated to update the userscripts. It contains the latest changes from the main branch, and should be merged when the new release is ready.
                   branch: update-userscripts
-                  reviewers: Robot-Inventor
+                  reviewers: ${{ github.repository_owner }}


### PR DESCRIPTION
- Ensure each "update userscripts" PR is reviewed by the repository owner

Fix the issue that prevents the update userscripts CI from running on forked repositories.